### PR TITLE
Refactor round data extraction

### DIFF
--- a/contracts/ChainlinkOracle.sol
+++ b/contracts/ChainlinkOracle.sol
@@ -6,6 +6,12 @@ import "solidity-bytes-utils/contracts/BytesLib.sol";
 contract ChainlinkOracle {
     using BytesLib for bytes;
 
+    struct Round {
+        uint80 roundId;
+        int128 answer;
+        uint32 timestamp;
+    }
+
     /*
         pub struct Transmission {
             pub slot: u64,
@@ -17,11 +23,14 @@ contract ChainlinkOracle {
         }
     */
     uint private constant transmissionTimestampOffset = 8;  // slot:8
-    uint private constant transmissionAnswerOffset  = 16;   // slot:8 + timestamp:4 + _padding0:4
+    uint private constant transmissionAnswerOffset = 16;    // slot:8 + timestamp:4 + _padding0:4
 
-    function getRoundData(bytes memory transmission) public pure returns (uint32 timestamp, int128 answer) {
-        timestamp = readLittleEndianUnsigned32(transmission.toUint32(transmissionTimestampOffset));
-        answer = readLittleEndianSigned128(transmission.toUint128(transmissionAnswerOffset));
+    // Data extraction helpers
+
+    function extractRound(uint80 roundId, bytes memory transmission) public pure returns (Round memory) {
+        uint32 timestamp = readLittleEndianUnsigned32(transmission.toUint32(transmissionTimestampOffset));
+        int128 answer = readLittleEndianSigned128(transmission.toUint128(transmissionAnswerOffset));
+        return Round(roundId, answer, timestamp);
     }
 
     // Little endian helpers

--- a/test/chainlink_oracle.js
+++ b/test/chainlink_oracle.js
@@ -1,13 +1,13 @@
 const ChainlinkOracle = artifacts.require("ChainlinkOracle");
 
 contract("ChainlinkOracle", () => {
-  let oracle
+  let oracle;
 
   beforeEach(async () => {
     oracle = await ChainlinkOracle.deployed();
   });
 
-  describe(".getRoundData", function () {
+  describe(".extractRound", function () {
     /*
       Raw Transmission data sample:
 
@@ -21,16 +21,24 @@ contract("ChainlinkOracle", () => {
     const transmission = "0x" +
       "242e43080000000040049a6200000000" +
       "556eb502290000000000000000000000" +
-      "00000000000000000000000000000000"
+      "00000000000000000000000000000000";
+
+    const roundIdInput = 31337;
+
+    it('should set round id', async () => {
+      let { roundId } = await oracle.extractRound(roundIdInput, transmission);
+
+      assert.equal(roundId, 31337);
+    });
 
     it('should extract timestamp of a round from transmission struct data', async () => {
-      let { timestamp } = await oracle.getRoundData(transmission);
+      let { timestamp } = await oracle.extractRound(roundIdInput, transmission);
 
       assert.equal(timestamp, 1654260800);
     });
 
     it('should extract answer of a round from transmission struct data', async () => {
-      let { answer } = await oracle.getRoundData(transmission);
+      let { answer } = await oracle.extractRound(roundIdInput, transmission);
 
       assert.equal(answer, 176139103829);
     });


### PR DESCRIPTION
- introduce `Round` struct
- rename `getRoundData()` to prevent a conflict with `AggregatorV3Interface`