### PR TITLE
Fix returning potentially incorrect data in case of Chainlink oracle faults

### DIFF
--- a/contracts/libraries/Utils.sol
+++ b/contracts/libraries/Utils.sol
@@ -180,6 +180,11 @@ library Utils {
 
     function extractRound(uint32 roundId, bytes memory rawTransmission) public pure returns (Round memory) {
         uint32 timestamp = readLittleEndianUnsigned32(rawTransmission.toUint32(TRANSMISSION_TIMESTAMP_OFFSET));
+
+        // Ported behaviour
+        // https://github.com/smartcontractkit/chainlink/blob/026e9a69dbcb057123264392e1e5a0c2c03e96f0/contracts/src/v0.6/AggregatorFacade.sol#L203
+        require(timestamp > 0, "No data present");
+
         int128 answer = readLittleEndianSigned128(rawTransmission.toUint128(TRANSMISSION_ANSWER_OFFSET));
         return Round(roundId, answer, timestamp);
     }

--- a/test/libraries/utils.js
+++ b/test/libraries/utils.js
@@ -42,6 +42,24 @@ contract("Utils", () => {
 
       assert.equal(answer, 176139103829);
     });
+
+    describe('when transmission is not ready', async () => {
+      const transmission = "0x" +
+      "00000000000000000000000000000000" +
+      "00000000000000000000000000000000" +
+      "00000000000000000000000000000000";
+
+      it('reverts', async () => {
+        try {
+          await utils.extractRound(_roundId, transmission);
+          throw null;
+        }
+        catch (error) {
+          assert(error, "Expected an error but did not get one");
+          assert(error.message.endsWith("No data present"));
+        }
+      });
+    })
   });
 
   describe(".extractRound", () => {


### PR DESCRIPTION
We do not want to return incorrect data in case of a new round has not reached consensus or the data is simply broken