### PR TITLE
Locking all contracts pragma version to  0.8.19

### DIFF
--- a/contracts/ChainlinkOracle.sol
+++ b/contracts/ChainlinkOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.19;
 
 import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 import "./libraries/Utils.sol";

--- a/contracts/libraries/Utils.sol
+++ b/contracts/libraries/Utils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.19;
 
 import "solidity-bytes-utils/contracts/BytesLib.sol";
 import "./external/QueryAccount.sol";

--- a/contracts/libraries/external/QueryAccount.sol
+++ b/contracts/libraries/external/QueryAccount.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.7.0;
+pragma solidity 0.8.19;
 
 /**
  * @title QueryAccount

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -24,7 +24,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: "0.8.15",      // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.8.19",      // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       // settings: {          // See the solidity docs for advice about optimization and evmVersion
       //  optimizer: {


### PR DESCRIPTION
It's considered a security best practice to lock pragma version