### PR TITLE
Adapt round lookup in case of empty history ringbuffer

### DIFF
--- a/contracts/libraries/Utils.sol
+++ b/contracts/libraries/Utils.sol
@@ -127,7 +127,7 @@ library Utils {
     {
         uint32 liveStartRoundId = saturatingSub(latestRoundId, liveLength - 1);
         uint32 historicalEndRoundId = latestRoundId - (latestRoundId % granularity);
-        uint32 historicalStartRoundId = saturatingSub(historicalEndRoundId, granularity * (historicalLength - 1));
+        uint32 historicalStartRoundId = saturatingSub(historicalEndRoundId, granularity * saturatingSub(historicalLength, 1));
 
         // If withing the live range, fetch from it. Otherwise, fetch from the closest previous in history.
         if (roundId >= liveStartRoundId && roundId <= latestRoundId) {

--- a/test/libraries/utils.js
+++ b/test/libraries/utils.js
@@ -253,5 +253,33 @@ contract("Utils", () => {
         assert.equal(position, 7);
       });
     })
+
+    describe('when historical data does not present', async () => {
+      const liveCursor = 0
+      const liveLength = 1
+      const latestRoundId = 38
+      const historicalCursor = 0
+      const historicalLength = 0
+      const granularity = 1
+
+      it('reverts', async () => {
+        try {
+          await utils.locateRound(
+            42,
+            liveCursor,
+            liveLength,
+            latestRoundId,
+            historicalCursor,
+            historicalLength,
+            granularity
+          );
+          throw null;
+        }
+        catch (error) {
+          assert(error, "Expected an error but did not get one");
+          assert(error.message.endsWith("No data present"), "Expected no data present error, but received " + error);
+        }
+      });
+    })
   })
 });


### PR DESCRIPTION
Relative changes in Chainlink implementation https://github.com/smartcontractkit/chainlink-solana/pull/380